### PR TITLE
Allow incremental syncs for subsequent exports

### DIFF
--- a/src/export.js
+++ b/src/export.js
@@ -1,14 +1,48 @@
+const fs = require('fs');
+const path = require('path');
+
 // service handlers
 let services = {
     github: require('./services/github'),
     gitlab: require('./services/gitlab')
 };
 
+function cleanUpFileAndExtractLastSyncDate(filePath) {
+    let lastSyncDate = null;
+
+    if (fs.existsSync(filePath)) {
+        let fileContent = fs.readFileSync(filePath, 'utf-8').trim();
+        let lines = fileContent.split('\n');
+
+        if (lines.length > 0) {
+            let lastEntry = JSON.parse(lines[lines.length - 1]);
+            let lastEntryDate = new Date(lastEntry.timestamp).toISOString().split('T')[0];
+
+            // Remove all lines with last entry's date
+            lines = lines.filter(line => {
+                let entryDate = new Date(JSON.parse(line).timestamp).toISOString().split('T')[0];
+                return entryDate !== lastEntryDate;
+            });
+
+            // Rewrite file with remaining lines
+            fs.writeFileSync(filePath, lines.join('\n') + '\n', 'utf-8');
+        }
+
+        // Read new last line and extract its date
+        if (lines.length > 0) {
+            let newLastEntry = JSON.parse(lines[lines.length - 1]);
+            lastSyncDate = new Date(newLastEntry.timestamp).toISOString();
+        }
+    }
+
+    return lastSyncDate;
+}
+
 // cmd definition
 module.exports = {
 
     // command usage text
-    command: 'export <service> <token>',
+    command: 'export <service> <token> [exportFilename] [date]',
 
     // command description text for the CLI
     describe: 'Exports a sorted array of activity.',
@@ -23,23 +57,37 @@ module.exports = {
             .positional('token', {
                 describe: 'The token of the account to authenticate with.'
             })
+            .positional('exportFilename', {
+                describe: 'The filename to export the git activity to.',
+                default: 'export.jsonl'
+            })
+            .positional('date', {
+                describe: 'The date to export from.',
+                default: '2005-01-01T00:00:00Z'
+            })
             .require('service')
             .require('token');
     },
 
-    // command handler definition
     handler: async function (args) {
-        // pull the actions from the service handler
-        let actions = await services[args.service](args);
+        const exportFilePath = path.join(__dirname, '..', args.exportFilename);
+        console.log('Exporting git activity to:', exportFilePath);
+        
+        let lastSyncDate = cleanUpFileAndExtractLastSyncDate(exportFilePath);
 
-        // sort actions by timestamp
-        actions.sort(function (left, right) {
-            return left.timestamp.valueOf() - right.timestamp.valueOf();
-        });
-
-        // write all to stdout
-        for (let action of actions) {
-            console.log(JSON.stringify(action));
+        if (lastSyncDate) {
+            args.date = lastSyncDate
         }
+
+        console.log('Exporting activity starting from:', args.date);
+        
+        let actions = await services[args.service](args);
+        actions.sort((left, right) => left.timestamp.valueOf() - right.timestamp.valueOf());
+
+        for (let action of actions) {
+            fs.appendFileSync(exportFilePath, JSON.stringify(action) + '\n');
+        }
+
+        console.log('Number of activities exported:', actions.length);
     }
 };

--- a/src/services/github.js
+++ b/src/services/github.js
@@ -30,7 +30,9 @@ module.exports = async function fetch(args) {
     // initialize timestamps
     let user = viewer.viewer;
     let author = `${user.name} <${user.email}>`;
-    let created = moment.utc(user.createdAt);
+    // github includes start date activities also which 
+    // we don't want in incremental sync    
+    let created = moment.utc(args.date).add(1, 'days'); 
     let current = moment.utc();
 
     // walk through all actions (yearly)

--- a/src/services/gitlab.js
+++ b/src/services/gitlab.js
@@ -37,7 +37,8 @@ module.exports = async function fetch(args) {
     for (let type of enabled) {
         // walk the events of the user matching the entry type
         let events = await client.Users.allEvents(user.id, {
-            action: type
+            action: type,
+            after: args.date
         });
 
         // walk all user events


### PR DESCRIPTION
@whitfin Thanks for this utility! It worked great so far. 👍 

Not sure if you were already planning for this, but to make this more efficient, I've added the capability to perform incremental export for every export after the 1st one. 

Further, blame it on my poor memory 😅, but I kept forgetting to provide the filename to export to.  So, I went ahead and made that an optional argument to the CLI. Since we now no longer redirect stdout to a file, it enables us to print useful stats of the export operation. Without any visual feedback from the CLI earlier, it seemed like the cmd was stuck without doing anything. 

This commit does the following:
- Adds capability to perform incremental syncs for subsequent exports.
- Adds a new "optional" cmd line arg for file name to "export to" and "import from" to import and export cmds.
- Adds a new "optional" cmd line arg to specify the start date to export from. 

### CLI cmd to `export` contributions (from gitlab):
```
# This will export gitlab contributions to export.jsonl
gitivity export gitlab <gitlab-access-token>
```

### CLI cmd for `import`
```
# This will import the gitlab contributions from export.jsonl to a local my-gitlab-activity dir
gitivity import my-gitlab-activity
```

Tested the following cases:
1. Export(full-export) from Gitlab without providing filename as input arg.
2. Export(incremental-export) from Gitlab without providing filename as input arg.
3. Export(full-export) from Gitlab providing filename as input arg.
4. Export(incremental-export) from Gitlab providing filename as input arg.
6. Export(partial-export) from Gitlab providing filename and date as input args.
7. Import gitlab activities without providing filename as input arg.
8. Import gitlab activities providing filename as input arg.

The above tests were repeated for Github export and import too.

Let me know if there are any questions. Thanks!
