### PR TITLE
Add GitLab & GitHub Enterprise Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,14 @@ The main difference with this approach is that because the `mirror` command has 
 of the output repository, it can use the latest commit timestamp to enable incremental
 exports.
 
+## GitHub & GitLab Enterprise
+
+If you need to use a custom host, you can specify it with the `--host` option:
+
+```bash
+gitivity mirror gitlab glpat-_******************* my-gitlab-activity --host https://gitlab.example.com
+```
+
 ## How It Works
 
 The idea here is pretty simple. You first export your commit data from a service (e.g. GitLab)

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ If you need to use a custom host, you can specify it with the `--host` option:
 
 ```bash
 gitivity mirror gitlab glpat-_******************* my-gitlab-activity --host https://gitlab.example.com
+gitivity mirror github glpat-_******************* my-gitlab-activity --host https://github.example.com
 ```
 
 ## How It Works

--- a/src/command/export.js
+++ b/src/command/export.js
@@ -28,7 +28,12 @@ export default {
             })
             .option('host', {
                 type: 'string',
-                description: 'Custom host URL (e.g., https://gitlab.example.com, https://github.example.com/api/v3).',
+                description:
+                    'Custom host URL (e.g., https://gitlab.example.com, https://github.example.com/api/v3).',
+            })
+            .option('ssl-no-verify', {
+                type: 'boolean',
+                description: 'Disable SSL certificate verification (insecure).',
             })
             .alias('f', 'from')
             .alias('h', 'host')

--- a/src/command/export.js
+++ b/src/command/export.js
@@ -26,7 +26,12 @@ export default {
                 type: 'string',
                 description: 'A lower bound timestamp to export from.',
             })
+            .option('host', {
+                type: 'string',
+                description: 'Custom host URL (e.g., https://gitlab.example.com, https://github.example.com/api/v3).',
+            })
             .alias('f', 'from')
+            .alias('h', 'host')
             .require('service')
             .require('token');
     },

--- a/src/services/github.js
+++ b/src/services/github.js
@@ -10,9 +10,10 @@ import { Octokit } from '@octokit/rest';
  *      an array of actions to emit to stdout.
  */
 export default async function* fetch(args) {
-    // open GitHub API cliemt
+    // open GitHub API client with custom host if provided
     let client = new Octokit({
         auth: args.token,
+        ...(args.host && { baseUrl: args.host })
     });
 
     // retrieve the current user info

--- a/src/services/github.js
+++ b/src/services/github.js
@@ -10,10 +10,14 @@ import { Octokit } from '@octokit/rest';
  *      an array of actions to emit to stdout.
  */
 export default async function* fetch(args) {
+    if (args.sslNoVerify) {
+        throw new Error('Unsupported option for GitHub: --ssl-no-verify');
+    }
+
     // open GitHub API client with custom host if provided
     let client = new Octokit({
         auth: args.token,
-        ...(args.host && { baseUrl: args.host })
+        ...(args.host && { baseUrl: args.host }),
     });
 
     // retrieve the current user info

--- a/src/services/gitlab.js
+++ b/src/services/gitlab.js
@@ -12,9 +12,10 @@ import { Gitlab } from '@gitbeaker/rest';
 export default async function* fetch(args) {
     let actions = [];
 
-    // open Gitlab API cliemt
+    // open Gitlab API client with custom host if provided
     let client = new Gitlab({
         token: args.token,
+        ...(args.host && { host: args.host }),
     });
 
     // fetch current user metadata for author tag

--- a/src/services/gitlab.js
+++ b/src/services/gitlab.js
@@ -43,7 +43,7 @@ export default async function* fetch(args) {
 
         // lower bounds
         if (args.from) {
-            opts.after = moment.utc(opts.after).format('YYYY-MM-DD');
+            opts.after = moment.utc(args.from).format('YYYY-MM-DD');
         }
 
         // walk the events of the user matching the entry type


### PR DESCRIPTION
## Overview

This adds an optional `--host` argument to support providing a custom base URL for both the GitLab and GitHub services to support private self-hosted Enterprise instances. Also fixes lower bound date issue in `mirror` command.

## Source Changes

- Add `host` option to `export` command (e.g. `--host https://gitlab.example.com`)
- Enhance GitLab service to configure `host` in client if provided.
- Enhance GitHub service to configure `baseUrl` in client if provided.
- Fix `mirror` issue where lower bound date was ignored with no new activity ever found.

## Additional Information

✔️ Verified the following from private GitLab Enterprise Edition [v17.9.6-ee](https://gitlab.com/gitlab-org/gitlab/-/tags/v17.9.6-ee) :

```shell
gitivity export gitlab "$GITLAB_TOKEN" \
  --host "https://$GITLAB_HOST" > "export.jsonl"
```
```shell
gitivity mirror gitlab "$GITLAB_TOKEN" . \
  --host "https://$GITLAB_HOST"
```

## Related Links

- Fixes #1
- [@gitbeaker/rest API Client Documentation](https://github.com/jdalrymple/gitbeaker/blob/main/packages/rest/README.md#api-client) - Client support for `host` to provide GitLab Instance Host URL
- [@octokit/rest Client Documentation](https://octokit.github.io/rest.js/v21/) - Client support for `baseUrl` to use with GitHub Enterprise